### PR TITLE
fix: use exclusive keyboard interactivity for capture overlay

### DIFF
--- a/src/ui/capture_overlay.cpp
+++ b/src/ui/capture_overlay.cpp
@@ -1418,7 +1418,7 @@ CaptureOverlay::CaptureOverlay(hyprcapture::CaptureDefaults defaults, bool quick
         layerWindow->setAnchors(LayerShellQt::Window::Anchors{LayerShellQt::Window::AnchorTop} | LayerShellQt::Window::AnchorBottom |
                                 LayerShellQt::Window::AnchorLeft | LayerShellQt::Window::AnchorRight);
         layerWindow->setExclusiveZone(-1);
-        layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
+        layerWindow->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityExclusive);
         layerWindow->setActivateOnShow(true);
         layerWindow->setDesiredSize(QSize(0, 0));
     }


### PR DESCRIPTION
Fixes #6 

As mentioned there, fullscreen games keep the mouse and keyboard focus, so it's not possible to take screenshots or close the overlay currently.
Switching to `KeyboardInteractivityExclusive` should fix that, which reading from the official docs should be the correct mode to use: 

> Request exclusive keyboard focus if this surface is above the shell surface layer.

Links:
* https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:enum:keyboard_interactivity
* https://invent.kde.org/plasma/layer-shell-qt/-/blob/master/src/interfaces/window.h for the enum mapping (line 66)